### PR TITLE
Fix 0 step error on range

### DIFF
--- a/src/ArrayMetaClient.php
+++ b/src/ArrayMetaClient.php
@@ -59,7 +59,7 @@ class ArrayMetaClient
      */
     public static function range($start, $end, $step = 1)
     {
-        if (!\is_numeric($step)) {
+        if (!\is_numeric($step) || $step == 0) {
             throw new InvalidArgumentException();
         }
         return new ArrayMeta(\range($start, $end, $step));

--- a/tests/Unit/ArrayMetaClientTest.php
+++ b/tests/Unit/ArrayMetaClientTest.php
@@ -155,4 +155,18 @@ class ArrayMetaClientTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(26, $meta);
     }
+
+    public function testRangeThrowsExceptionWhenStepIsZero()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        ArrayMetaClient::range(1, 10, 0);
+    }
+
+    public function testRangeThrowsExceptionWhenStepIsStringZero()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        ArrayMetaClient::range(1, 10, '0');
+    }
 }


### PR DESCRIPTION
This PR

* [x] Fixes an error that would occur if the step was 0 for the range function

Follows #28 .